### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "my-app",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
Prepare release `v1.0.1`

This PR bumps `package.json` and `package-lock.json` to version `1.0.1` and includes the release tag `v1.0.1`. Merge this PR to update `main` and create the release tag for production.

Changes
- `package.json`: version -> 1.0.1
- `package-lock.json`: version -> 1.0.1
- No source-code behavior changes beyond the merged PRs already in `main`.

Release notes (short)
- Show student name in App
- Merge teammate `newText` changes and resolve conflicts
- Version bump to 1.0.1

Verification steps
1. Confirm `package.json` and `package-lock.json` both show `"version": "1.0.1"`.
2. Merge this PR, then ensure the tag `v1.0.1` points to the merge commit.
